### PR TITLE
Add MotoGP NFT contract and script to get collection

### DIFF
--- a/scripts/collections.cdc
+++ b/scripts/collections.cdc
@@ -10,6 +10,7 @@ import NonFungibleToken from "../contracts/standard/NonFungibleToken.cdc"
 import GooberXContract from 0x34f2bf4a80bb0f69
 import Flovatar from 0x921ea449dffec68a
 import RareRooms_NFT from 0x329feb3ab062d289
+import MotoGPCard from 0xa49cc0ee46c54bfb
 
 pub struct MetadataCollection{
 	pub let type: String
@@ -142,6 +143,25 @@ pub fun main(address: Address) : {String : MetadataCollection}? {
 		}
 		results["RareRooms"] = MetadataCollection(type: Type<@RareRooms_NFT.Collection>().identifier, items: items)
 	}
+
+
+	let motoGPCollection = account.getCapability<&MotoGPCard.Collection{MotoGPCard.ICardCollectionPublic}>(/public/motogpCardCollection)
+	if motoGPCollection.check() {
+		let motoGPNfts = motoGPCollection.borrow()!.getIDs()
+		let items: [MetadataCollectionItem] = []
+		for id in motoGPNfts {
+			let nft = motoGPCollection.borrow()!.borrowCard(id: id)!
+			let metadata = nft.getCardMetadata()!
+			items.append(MetadataCollectionItem(
+				id: id,
+				name: metadata.name,
+				image: metadata.imageUrl,
+				url: "https://motogp-ignition.com/"
+			))
+		}
+		results["MotoGP"]= MetadataCollection(type: Type<@MotoGPCard.Collection>().identifier, items: items)
+	}
+
 
 	if results.keys.length == 0 {
 		return nil

--- a/scripts/collections.cdc
+++ b/scripts/collections.cdc
@@ -156,7 +156,7 @@ pub fun main(address: Address) : {String : MetadataCollection}? {
 				id: id,
 				name: metadata.name,
 				image: metadata.imageUrl,
-				url: "https://motogp-ignition.com/"
+				url: "https://motogp-ignition.com/nft/card/".concat(id.toString()).concat("?owner=").concat(address.toString()),
 			))
 		}
 		results["MotoGP"]= MetadataCollection(type: Type<@MotoGPCard.Collection>().identifier, items: items)


### PR DESCRIPTION
Similar to #7 , I'm not affiliated to Animoca who wrote that contract. I'm just a holder of MotoGP NFT and I'd love to see that NFT in my .find collection.

Smart contract: https://flow-view-source.com/mainnet/account/0xa49cc0ee46c54bfb/contract/MotoGPCard

MotoGPMetadata looks like this
```
A.a49cc0ee46c54bfb.MotoGPCardMetadata.Metadata(
	cardID: 3019,
	name: "Miguel Oliveira",
	description: "Miguel Oliveira's two retirements early didn't go on to set precendent for his 2020 season, with the rider getting two first place finishes, with one of which being his first in MotoGP.",
	imageUrl: "https://assets.motogp-ignition.com/MGPI-card-3019.jpg",
	data: {
		"grade": "Common",
		"team": "Red Bull KTM Tech 3",
		"season": "2020",
		"style": "Base",
		"theme": "2020 Competitors",
		"type": "Team",
		"number": "88"
	}
)
```