### PR TITLE
Add OneFootballCollectible to .find

### DIFF
--- a/scripts/collections.cdc
+++ b/scripts/collections.cdc
@@ -16,6 +16,7 @@ import MatrixWorldFlowFestNFT from 0x2d2750f240198f91
 import SturdyItems from 0x427ceada271aa0b1
 import Evolution from 0xf4264ac8f3256818
 import GeniaceNFT from 0xabda6627c70c7f52
+import OneFootballCollectible from 0x6831760534292098
 
 
 pub struct MetadataCollections {
@@ -516,8 +517,7 @@ pub fun main(address: Address) : MetadataCollections? {
 	}
 
 
-  let geniaceCap = account.getCapability<&GeniaceNFT.Collection{NonFungibleToken.CollectionPublic, GeniaceNFT.GeniaceNFTCollectionPublic}>(GeniaceNFT.CollectionPublicPath)
-
+	let geniaceCap = account.getCapability<&GeniaceNFT.Collection{NonFungibleToken.CollectionPublic, GeniaceNFT.GeniaceNFTCollectionPublic}>(GeniaceNFT.CollectionPublicPath)
 	if geniaceCap.check() {
 		let geniace=geniaceCap.borrow()!
 		let nfts = geniace.getIDs()
@@ -553,6 +553,35 @@ pub fun main(address: Address) : MetadataCollections? {
 
 		if items.length != 0 {
 			results["Geniace"] = items
+		}
+	}
+
+	// https://flow-view-source.com/mainnet/account/0x6831760534292098/contract/OneFootballCollectible
+	let OneFootballCollectibleCap = account.getCapability<&OneFootballCollectible.Collection{OneFootballCollectible.OneFootballCollectibleCollectionPublic}>(OneFootballCollectible.CollectionPublicPath)
+	if OneFootballCollectibleCap.check() {
+		let items: [String] = []
+		let collection = OneFootballCollectibleCap.borrow()!
+		for id in collection.getIDs() {
+			let nft = collection.borrowOneFootballCollectible(id: id)!
+			let metadata = nft.getTemplate()!
+			let item=MetadataCollectionItem(
+				id: id,
+				name: metadata.name,
+				image: "ipfs://".concat(metadata.media),
+				url: "https://xmas.onefootball.com/".concat(account.address.toString()),
+				listPrice: nil,
+				listToken: nil,
+				contentType: "video",
+				rarity: ""
+
+			)
+			let itemId="OneFootballCollectible".concat(id.toString())
+			items.append(itemId)
+			resultMap[itemId] = item
+
+		}
+		if items.length != 0 {
+			results["OneFootballCollectible"] = items
 		}
 	}
 


### PR DESCRIPTION
```sh
→ flow scripts execute collections.cdc 0x90bd6b4845e310a0 -n mainnet                                                                                                           <aws:of-prod>

⚠️  Version warning: a new version of Flow CLI is available (v0.30.2).
   Read the installation guide for upgrade instructions: https://docs.onflow.org/flow-cli/install


Result: s.3d8448c7f8f15cd04307eb3bbe00e824e0cbe378a48f9857b5efa01306d15caa.MetadataCollections(items: {"OneFootballCollectible90": s.3d8448c7f8f15cd04307eb3bbe00e824e0cbe378a48f9857b5efa01306d15caa.MetadataCollectionItem(id: 90, name: "Louis, OneFootballerz #78", image: "ipfs://bafybeif26dqnotrgz5mkbuuj2vsv7wmpii7ymdwu7jhv5e4f55aewitela", url: "https://xmas.onefootball.com/0x90bd6b4845e310a0", listPrice: nil, listToken: nil, contentType: "video", rarity: "")}, collections: {"OneFootballCollectible": ["OneFootballCollectible90"]}, curatedCollections: {})
```