### PR TITLE
Fix market transactions

### DIFF
--- a/transactions/bidMarketAuctionEscrowed.cdc
+++ b/transactions/bidMarketAuctionEscrowed.cdc
@@ -279,7 +279,7 @@ transaction(marketplace:Address, user: String, id: UInt64, amount: UFix64) {
 
 		self.bidsReference= account.borrow<&FindMarketAuctionEscrow.MarketBidCollection>(from: bidSstoragePath)
 		self.balanceBeforeBid=self.walletReference.balance
-		self.pointer= FindViews.createViewReadPointer(address: address, path:nft.publicPath, id: id)
+		self.pointer= FindViews.createViewReadPointer(address: address, path:nft.publicPath, id: item.getItemID())
 	}
 
 	pre {

--- a/transactions/fulfillMarketDirectOfferEscrowed.cdc
+++ b/transactions/fulfillMarketDirectOfferEscrowed.cdc
@@ -26,7 +26,7 @@ transaction(marketplace:Address, id: UInt64) {
 			)
 		}
 
-		let pointer= FindViews.AuthNFTPointer(cap: providerCap, id: id)
+		let pointer= FindViews.AuthNFTPointer(cap: providerCap, id: item.getItemID())
 		let market = account.borrow<&FindMarketDirectOfferEscrow.SaleItemCollection>(from: storagePath)!
 		market.acceptDirectOffer(pointer)
 


### PR DESCRIPTION
- Transactions that first bring the NFT onto Find Market / no saleItem created on FindMarket
       requires nftAliasOrIdentifier and NFT ID 

- Transactions with items that are already recognized by FindMarket / already have saleItem created on FindMarket 
       requires only saleItemID (i.e. NFT uuid) 

So it can be even easier that: 
If a transaction requires nftAliasOrIdentifier, it takes NFT ID, otherwise it would be NFT uuid