### PR TITLE
fix find pack script

### DIFF
--- a/scripts/getFindPackSaleDetailsWithUser.cdc
+++ b/scripts/getFindPackSaleDetailsWithUser.cdc
@@ -100,7 +100,7 @@ pub fun getSoonestQualifiedSale(_ infos: [FindPack.SaleInfo], user: Address) : U
 
 	// if there is no option available, get the soonest option available to the user, again, lowest price
 			if info.checkBuyable(addr: user, time: info.startTime) {
-				if soonestOption == nil || soonestOption!.startTime < info.startTime {
+				if soonestOption == nil || soonestOption!.startTime > info.startTime {
 					soonestOption = info
 				} else if soonestOption!.startTime == info.startTime && soonestOption!.price > info.price {
 					soonestOption = info

--- a/tq
+++ b/tq
@@ -1,0 +1,2 @@
+#!/bin/bash
+flow scripts execute -n testnet $@  -o json | ./overflow-json


### PR DESCRIPTION
This one > arrow makes the script returns the latest sale they are eligible to instead of the earliest. 

I will add tests to the script later. Linear added. 
But would like to have this in the latest client to serve for flomies