### PR TITLE
fix furnace and sendNFTs Script

### DIFF
--- a/contracts/FindFurnace.cdc
+++ b/contracts/FindFurnace.cdc
@@ -6,7 +6,7 @@ pub contract FindFurnace {
 
     pub event Burned(from: Address , id: UInt64, uuid: UInt64, type: String, title: String, thumbnail: String, nftInfo: FindMarket.NFTInfo, context: {String : String})
 
-    pub fun burn(pointer: FindViews.AuthNFTPointer, path: PublicPath, context: {String : String}) {
+    pub fun burn(pointer: FindViews.AuthNFTPointer, context: {String : String}) {
         if !pointer.valid() {
             panic("Invalid NFT Pointer. Type : ".concat(pointer.itemType.identifier).concat(" ID : ").concat(pointer.uuid.toString()))
         }

--- a/scripts/sendNFTs.cdc
+++ b/scripts/sendNFTs.cdc
@@ -67,14 +67,14 @@ pub fun main(sender: Address, nftIdentifiers: [String],  allReceivers:[String] ,
 				user = checkUser!
 			}
 
+			
 			var isDapper=false
-			if let receiver =account.getCapability<&{FungibleToken.Receiver}>(/public/flowTokenReceiver).borrow() {
+			if let receiver =getAccount(user!).getCapability<&{FungibleToken.Receiver}>(/public/flowTokenReceiver).borrow() {
 			 	isDapper=receiver.isInstance(Type<@TokenForwarding.Forwarder>())
 			} else {
-				if let duc = account.getCapability<&{FungibleToken.Receiver}>(/public/dapperUtilityCoinReceiver).borrow() {
+				if let duc = getAccount(user!).getCapability<&{FungibleToken.Receiver}>(/public/dapperUtilityCoinReceiver).borrow() {
 					isDapper = duc.isInstance(Type<@TokenForwarding.Forwarder>())
 				}
-				isDapper = false
 			}
 
 			// check receiver account storage 

--- a/scripts/sendNFTs.cdc
+++ b/scripts/sendNFTs.cdc
@@ -66,6 +66,11 @@ pub fun main(sender: Address, nftIdentifiers: [String],  allReceivers:[String] ,
 				addresses[receiver] = checkUser!
 				user = checkUser!
 			}
+			let checkAcct = getAccount(user!)
+			if checkAcct.balance == 0.0 {
+				report.append(logErr(i, err: "Account is not an activated account"))
+				continue
+			}
 
 			
 			var isDapper=false

--- a/transactions/burnNFTs.cdc
+++ b/transactions/burnNFTs.cdc
@@ -9,12 +9,10 @@ import FindFurnace from "../contracts/FindFurnace.cdc"
 transaction(types: [String] , ids: [UInt64], messages: [String]) {
 
 	let authPointers : [FindViews.AuthNFTPointer]
-	let paths : [PublicPath]
 
 	prepare(account : AuthAccount) {
 
 		self.authPointers = []
-		self.paths = []
 
 		let contractData : {Type : NFTCatalog.NFTCatalogMetadata} = {}
 
@@ -49,7 +47,6 @@ transaction(types: [String] , ids: [UInt64], messages: [String]) {
 			}
 			let pointer = FindViews.AuthNFTPointer(cap: providerCap, id: ids[i])
 			self.authPointers.append(pointer)
-			self.paths.append(path.publicPath)
 		}
 	}
 
@@ -57,10 +54,9 @@ transaction(types: [String] , ids: [UInt64], messages: [String]) {
 		for i,  pointer in self.authPointers {
 			let id = ids[i] 
 			let message = messages[i]
-			let path = self.paths[i]
 
 			// burn thru furnace
-			FindFurnace.burn(pointer: pointer, path: path, context: {"message" : message})
+			FindFurnace.burn(pointer: pointer, context: {"message" : message})
 		}
 	}
 }


### PR DESCRIPTION
Furnace : path is redundant, remove it 
sendNFTs script: check if the receiver is Dapper account, "account" is a mistake (account is the sender)
