### PR TITLE
allow duplidates in single trait and multiple traits

### DIFF
--- a/contracts/FindMarket.cdc
+++ b/contracts/FindMarket.cdc
@@ -1358,12 +1358,6 @@ pub contract FindMarket {
 
 				for trait in traits {
 
-					if singleTrait != nil {
-						if singleTrait!.name == trait.name {
-							continue
-						}
-					}
-
 					let name = trait.name
 					let display = trait.displayType ?? "String"
 


### PR DESCRIPTION
Some projects like goats traits, will expose the same trait as Trait and Traits. This snippet will ignore all the traits with the same name with this code in place, And thus the trait for GoatTraits are not shown. 